### PR TITLE
set `autoImplicit` to false

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -4,7 +4,8 @@ open Lake DSL
 package «Combinatorics» where
   leanOptions := #[
     ⟨`pp.unicode.fun, true⟩, -- pretty-prints `fun a ↦ b`
-    ⟨`pp.proofs.withType, false⟩
+    ⟨`pp.proofs.withType, false⟩,
+    ⟨`autoImplicit, false⟩
   ]
   -- add any package configuration options here
 


### PR DESCRIPTION
Otherwise Lean will treat any undeclared symbols/names as an implicit variable. Note that `mathlib` also set `autoImplict` as `false`