### PR TITLE
bxmo_2017_p2 islands problem 

### DIFF
--- a/CombiBench/bxmo_2017_p2.lean
+++ b/CombiBench/bxmo_2017_p2.lean
@@ -75,20 +75,12 @@ partial def aliceWins (s : GameState m) (sA: Strategy m) (sB: Strategy m): Bool 
   if bobHasLost then True else
   aliceWins stateAfterBobsMove sA sB
 
-def solution_set : Set ℕ := sorry
+abbrev bxmo_2017_p2_solution : ℕ → Fin 2 := sorry
 
-/-- 214
-Let \\( n \\geqslant 2 \\) be an integer. Alice and Bob play a game concerning a country made of \\( n \\) islands. Exactly two of those \\( n \\) islands have a factory. Initially there is no bridge in the country. Alice and Bob take turns in the following way. In each turn, the player must build a bridge between two different islands \\( I_{1} \\) and \\( I_{2} \\) such that:
-
-- \\( I_{1} \\) and \\( I_{2} \\) are not already connected by a bridge;
-- at least one of the two islands \\( I_{1} \\) and \\( I_{2} \\) is connected by a series of bridges to an island with a factory (or has a factory itself). (Indeed, access to a factory is needed for the construction.)
-
-As soon as a player builds a bridge that makes it possible to go from one factory to the other, this player loses the game. (Indeed, it triggers an industrial battle between both factories.) If Alice starts, then determine (for each \\( n \\geqslant 2 \\)) who has a winning strategy.
-
-(Note: It is allowed to construct a bridge passing above another bridge.)
+/--
+Let \\( n \\geqslant 2 \\) be an integer. Alice and Bob play a game concerning a country made of \\( n \\) islands. Exactly two of those \\( n \\) islands have a factory. Initially there is no bridge in the country. Alice and Bob take turns in the following way. In each turn, the player must build a bridge between two different islands \\( I_{1} \\) and \\( I_{2} \\) such that:\n\n- \\( I_{1} \\) and \\( I_{2} \\) are not already connected by a bridge;\n- at least one of the two islands \\( I_{1} \\) and \\( I_{2} \\) is connected by a series of bridges to an island with a factory (or has a factory itself). (Indeed, access to a factory is needed for the construction.)\n\nAs soon as a player builds a bridge that makes it possible to go from one factory to the other, this player loses the game. (Indeed, it triggers an industrial battle between both factories.) If Alice starts, then determine (for each \\( n \\geqslant 2 \\)) who has a winning strategy.\n\n(Note: It is allowed to construct a bridge passing above another bridge.)
 -/
-theorem bxmo_2017_p2 : (n ∈ solution_set →
+theorem bxmo_2017_p2 : (bxmo_2017_p2_solution n = 0 →
   ∃ strategyA , ∀ strategyB, aliceWins m (GameState.initial m) strategyA strategyB)
-  ∧ (n ∉ solution_set →
-  ∃ strategyB, ∀ strategyA, ¬ aliceWins m (GameState.initial m) strategyA strategyB)
-  := by sorry
+  ∧ (bxmo_2017_p2_solution n = 1 →
+  ∃ strategyB, ∀ strategyA, ¬ aliceWins m (GameState.initial m) strategyA strategyB) := by sorry


### PR DESCRIPTION
This is a sketch of how I think the islands game could be formalised. It probably contains errors and is incomplete: there is an instance proof missing and I had to make one of the functions noncomputable because it requires a manual termination proof. These issues could of course be fixed. 

Probably it doesn't make sense to include problems of this type if we don't formalise them -- the risk of error is quite big. So I propose that if we want to include this we should also formalise a proof. 

One might also object to the convention that I introduce (island renaming), but this would be easy to change; we might even have to different versions of the formalisation. 

Closes #77 