### PR TITLE
Formalise: imo_2003_p1 subsets of {1, 2, ..., 1000000}

### DIFF
--- a/CombiBench/imo_2003_p1.lean
+++ b/CombiBench/imo_2003_p1.lean
@@ -6,5 +6,5 @@ def S := Finset.Icc 1 1000000
 $S$ is the set $\{1, 2, 3, \dots ,1000000\}$. Show that for any subset $A$ of $S$ with $101$ elements we can find $100$ distinct elements $x_i$ of $S$, such that the sets $\{a + x_i \mid a \in A\}$ are all pairwise disjoint.
 -/
 theorem imo_2003_p1 (A : Finset S) (hA: A.card = 101):
-  ∃ x : Fin 100 → S, (∀ i j, i ≠ j → x i ≠ x j) ∧
-  ∀ i j, Disjoint { a.1 + (x i).1 | a ∈ A } { a.1 + (x j).1 | a ∈ A } := by sorry
+  ∃ x : Function.Embedding (Fin 100) S,
+  ∀ i j, i ≠ j → Disjoint { a.1 + (x i).1 | a ∈ A } { a.1 + (x j).1 | a ∈ A } := by sorry


### PR DESCRIPTION
I'm using Fin 1000000 for S which starts at 0 instead of 1. However, this is equivalent to the original problem. What do you think?

Closes #109