### PR TITLE
imo_2006_p2

### DIFF
--- a/CombiBench/imo_2006_p2.lean
+++ b/CombiBench/imo_2006_p2.lean
@@ -57,7 +57,7 @@ noncomputable def TriangleDissection.numOfIsoscelesTriangle (C : TriangleDissect
       -- The triangle has two sides of equal length
       ((b.val - a.val : ℤ) = c.val - b.val ∨
        (c.val - b.val : ℤ) = N + a.val - c.val ∨
-       (N + a.val - c.val : ℤ) = c.val - b.val)}
+       (N + a.val - c.val : ℤ) = b.val - a.val)}
 
 abbrev imo_2006_p2_solution : ℕ := sorry
 


### PR DESCRIPTION
I think this PR needs some explanation maybe. But I am a bit too lazy to write all the details here. Here is a quick version:
`Diagonal` is the type of unoriented diagonals, `pt1` and `pt2` are its endpoints (they are modeled as Fin 2006). Assuming `pt1` is appears before `pt2` if we count from 0 and counterclockwise. So a diagonal is good iff `pt1 - pt2` is odd. The `clockwiseArc` is the clockwise arc connecting pt1 to pt2 (excluding these two points). So `d` intersects `d'` iff one of the endpoints of `d'` is in the `clockwiseArc` of d.pt1 to d.pt2.  A `Configuration` is 2003 diagonals that no two diagonals intersects. If d is a digonal such that the endpoints of d differ by 2, then it makes an isosceles triangle. So when we count isosceles triangle, we need to count those that are made from 1 diagonal and 2 sides and that are made from 2 diagonal and 1 sides.